### PR TITLE
Some optimisations

### DIFF
--- a/contracts/not-swap.clar
+++ b/contracts/not-swap.clar
@@ -5,11 +5,8 @@
 
 ;; error constants
 (define-constant ERR-UNAUTHORIZED (err u401))
-(define-constant ERR-SAME-PRINCIPAL (err u402))
-(define-constant ERR-SLIPPAGE (err u403))
-(define-constant ERR-LIQUIDITY (err u404))
-(define-constant ERR-NOT-PROVIDER (err u405))
-(define-constant ERR-YOU-POOR (err u420))
+(define-constant ERR-SLIPPAGE (err u501))
+(define-constant ERR-YOU-POOR (err u600))
 
 ;; constants
 (define-constant liq-creator-address 'SP3QZF1M1294FX796Q3QD4JR2AV0YX9XW2PMWBA45)
@@ -20,8 +17,6 @@
 (define-data-var is-liq-created bool false)
 (define-data-var liquidity-stx-reserve uint u0)
 (define-data-var liquidity-not-reserve uint u0)
-(define-data-var total-liquidity uint u0)
-(define-map liq-providers { provider: principal } { amount: uint })
 
 
 ;; read only functions 
@@ -47,19 +42,14 @@
   (ok {
     liq-stx-reserve: (var-get liquidity-stx-reserve),
     liq-not-reserve: (var-get liquidity-not-reserve),
-    liq-token-supply: (var-get total-liquidity)
+    liq-token-supply: (get-total-supply)
   })
-)
-(define-read-only (get-liq-provider-amnt (provider principal))
-  (ok (get amount (unwrap! (map-get? liq-providers { provider: provider }) ERR-NOT-PROVIDER)))
 )
 
 ;; public functions
 (define-public (transfer (amount uint) (from principal) (to principal) (memo (optional (buff 34))))
     (begin
-        (asserts! (is-eq from tx-sender) ERR-UNAUTHORIZED)
-        (asserts! (> amount u0) ERR-YOU-POOR)
-        (asserts! (not (is-eq from to)) ERR-SAME-PRINCIPAL)
+        (asserts! (or (is-eq from tx-sender) (is-eq from contract-caller)) ERR-UNAUTHORIZED)
         (ft-transfer? not-lp-tokens amount from to)
     )
 )
@@ -68,16 +58,14 @@
   (fold check-err (map send-token recipients) (ok true))
 )
 
-(define-public (add-liquidity (stx-amount uint) (not-amount uint) (min-lp-out uint))
+(define-public (add-liquidity (stx-deposit uint) (not-deposit uint) (min-lp-out uint))
   (begin
-    (asserts! (> stx-amount u0) ERR-YOU-POOR)
-    (asserts! (> not-amount u0) ERR-YOU-POOR)
+    (asserts! (> stx-deposit u0) ERR-YOU-POOR)
+    (asserts! (> not-deposit u0) ERR-YOU-POOR)
     (let (
       (current-stx-reserve (var-get liquidity-stx-reserve))
       (current-not-reserve (var-get liquidity-not-reserve))
-      (tot-liquidity (var-get total-liquidity))
-      (stx-deposit stx-amount)
-      (not-deposit not-amount)
+      (tot-liquidity (ft-get-supply not-lp-tokens))
       (lp-out-stx (/ (* stx-deposit tot-liquidity) current-stx-reserve))
       (lp-out-not (/ (* not-deposit tot-liquidity) current-not-reserve))
       (liquidity-to-mint (if (>= lp-out-stx lp-out-not) lp-out-not lp-out-stx))
@@ -87,26 +75,12 @@
       
       ;; Transfer STX and NOT to the contract
       (try! (stx-transfer? stx-deposit tx-sender (as-contract tx-sender)))
-      (try! (contract-call? 'SP32AEEF6WW5Y0NMJ1S8SBSZDAY8R5J32NBZFPKKZ.nope transfer not-amount tx-sender (as-contract tx-sender) none))
+      (try! (contract-call? 'SP32AEEF6WW5Y0NMJ1S8SBSZDAY8R5J32NBZFPKKZ.nope transfer not-deposit tx-sender (as-contract tx-sender) none))
       
       ;; Update reserves and mint LP tokens
       (var-set liquidity-stx-reserve (+ current-stx-reserve stx-deposit))
       (var-set liquidity-not-reserve (+ current-not-reserve not-deposit))
-      (var-set total-liquidity (+ tot-liquidity liquidity-to-mint))
       
-      ;; Update liq-providers map
-      (if (is-already-provider tx-sender)
-        (begin
-          (let (
-            (old-amount-provided (get amount (unwrap! (map-get? liq-providers { provider: tx-sender }) ERR-NOT-PROVIDER)))
-            (new-amount-provided (+ old-amount-provided liquidity-to-mint))
-          )
-            (map-set liq-providers { provider: tx-sender } { amount: new-amount-provided })        
-          )
-        )
-        (map-insert liq-providers { provider: tx-sender } { amount: liquidity-to-mint })
-      )
-
       ;; Mint LP tokens to the sender
       (try! (ft-mint? not-lp-tokens liquidity-to-mint tx-sender))
       (ok true)
@@ -115,76 +89,51 @@
 )
 
 (define-public (remove-liquidity (lp-token-amount uint) (min-stx-out uint) (min-not-out uint) (recipient principal))
-  (begin
-    (asserts! (> lp-token-amount u0) ERR-YOU-POOR)
-    (asserts! (is-eq tx-sender recipient) ERR-UNAUTHORIZED)
     (let (
       (current-stx-reserve (var-get liquidity-stx-reserve))
       (current-not-reserve (var-get liquidity-not-reserve))
-      (tot-liquidity (var-get total-liquidity))
       (lp-tokens lp-token-amount)
+      (tot-liquidity (ft-get-supply not-lp-tokens))
       (stx-amount (/ (* lp-tokens current-stx-reserve) tot-liquidity))
       (not-amount (/ (* lp-tokens current-not-reserve) tot-liquidity))
     )
+      (asserts! (or (is-eq tx-sender recipient) (is-eq contract-caller recipient)) ERR-UNAUTHORIZED)
+      (asserts! (> lp-token-amount u0) ERR-YOU-POOR)
       ;; Ensure withdrawals are ok with slippage
-      (asserts! (>= tot-liquidity lp-tokens) ERR-LIQUIDITY)
       (asserts! (and
                  (>= stx-amount min-stx-out)
                  (>= not-amount min-not-out))
                ERR-SLIPPAGE)
-
-
-      ;; Update liq-providers map
-      (asserts! (is-already-provider tx-sender) ERR-NOT-PROVIDER)
-      (let (
-        (old-amount-provided (get amount (unwrap! (map-get? liq-providers { provider: tx-sender }) ERR-NOT-PROVIDER)))
-      )
-        (begin 
-          (asserts! (>= old-amount-provided lp-tokens) ERR-LIQUIDITY)
-          (if (is-eq old-amount-provided lp-tokens)
-            (map-delete liq-providers { provider: tx-sender })
-            (let (
-              (new-amount-provided (- old-amount-provided lp-tokens))
-            )
-              (map-set liq-providers { provider: tx-sender } { amount: new-amount-provided })
-            )
-          ) 
-        )      
-      )
       
       ;; Burn LP tokens from the sender
       (try! (ft-burn? not-lp-tokens lp-tokens tx-sender))
       
       ;; Transfer STX and NOT to the sender
-      (try! (as-contract (stx-transfer? stx-amount (as-contract tx-sender) recipient)))
-      (try! (contract-call? 'SP32AEEF6WW5Y0NMJ1S8SBSZDAY8R5J32NBZFPKKZ.nope transfer not-amount (as-contract tx-sender) recipient none))
+      (try! (as-contract (stx-transfer? stx-amount tx-sender recipient)))
+      (try! (as-contract (contract-call? 'SP32AEEF6WW5Y0NMJ1S8SBSZDAY8R5J32NBZFPKKZ.nope transfer not-amount tx-sender recipient none)))
 
       
       ;; Update reserves
       (var-set liquidity-stx-reserve (- current-stx-reserve stx-amount))
       (var-set liquidity-not-reserve (- current-not-reserve not-amount))
-      (var-set total-liquidity (- tot-liquidity lp-tokens))
       
-      (ok (tuple (stx-amount not-amount)))
+      (ok {stx-amount: stx-amount, not-amount: not-amount})
     )
   )
-)
 
-(define-public (swap-stx-for-not (stx-amount uint) (min-not-out uint))
-  (begin
-    (asserts! (> stx-amount u0) ERR-YOU-POOR)
+(define-public (swap-stx-for-not (stx-in uint) (min-not-out uint))
     (let (
       (current-stx-reserve (var-get liquidity-stx-reserve))
       (current-not-reserve (var-get liquidity-not-reserve))
-      (stx-in stx-amount)
       (new-stx-reserve (+ current-stx-reserve stx-in))
       (k (* current-stx-reserve current-not-reserve))
       (new-not-reserve (/ k new-stx-reserve))
       (not-out (- current-not-reserve new-not-reserve))
       (not-liq-fee (/ (* not-out liq-providers-fee) u10000))
       (not-burn-fee (/ (* not-out burn-fee) u10000))
-      (not-out-after-fee (- not-out (+ not-liq-fee not-burn-fee)))
-    )
+      (not-out-after-fee (- not-out not-liq-fee not-burn-fee))
+      (user tx-sender))
+      (asserts! (> stx-in u0) ERR-YOU-POOR)
       ;; Check slippage
       (asserts! (>= not-out-after-fee min-not-out) ERR-SLIPPAGE)
       
@@ -192,7 +141,7 @@
       (try! (stx-transfer? stx-in tx-sender (as-contract tx-sender)))
 
       ;; Transfer NOT to the sender and retain not-liq-fee in the contract (liq providers rewards)
-      (try! (contract-call? 'SP32AEEF6WW5Y0NMJ1S8SBSZDAY8R5J32NBZFPKKZ.nope transfer not-out-after-fee (as-contract tx-sender) tx-sender none))
+      (try! (as-contract (contract-call? 'SP32AEEF6WW5Y0NMJ1S8SBSZDAY8R5J32NBZFPKKZ.nope transfer not-out-after-fee tx-sender user none)))
 
       ;; Burn NOT fee
       (try! (contract-call? 'SPEMB0KQRD7PWKY2W2J2Y1Y6Q9YBJ702DWQADE7V.not-incinerator-v3 burn-nothing not-burn-fee))
@@ -203,7 +152,6 @@
     
       (ok not-out-after-fee)
     )
-  )
 )
 
 (define-public (swap-not-for-stx (not-amount uint) (min-stx-out uint) (recipient principal))
@@ -259,7 +207,6 @@
       
       ;; Mint initial LP tokens equal to the geometric mean of the reserves
       (let ((initial-liquidity (sqrti (* initial-stx-reserve initial-not-reserve))))
-        (var-set total-liquidity initial-liquidity)
         
         ;; Mint LP tokens to burn address
         (try! (ft-mint? not-lp-tokens initial-liquidity 'SP000000000000000000002Q6VF78))
@@ -278,16 +225,6 @@
 )
 
 (define-private (send-token (recipient { to: principal, amount: uint, memo: (optional (buff 34)) }))
-  (send-token-with-memo (get amount recipient) (get to recipient) (get memo recipient))
-)
-
-(define-private (send-token-with-memo (amount uint) (to principal) (memo (optional (buff 34))))
-  (let ((transferOk (try! (transfer amount tx-sender to memo))))
-    (ok transferOk)
-  )
-)
-
-(define-private (is-already-provider (sender principal))
-    (is-some (map-get? liq-providers { provider: sender }))
+  (transfer (get amount recipient) tx-sender (get to recipient) (get memo recipient))
 )
 


### PR DESCRIPTION
This PR
* removes some unnecessary variables
* removes unnecessary begin
* adapts error codes to match http status
* removes map liq-providers and relies on ft data directly
* allows contract-callers to transfer from tx-sender
* fixes return value from remove-liquidity